### PR TITLE
add links to converter and tutorial

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,6 +24,10 @@ OpenIndexMaps use the [GeoJSON Format](https://tools.ietf.org/html/rfc7946) to d
 - 1\. Introduction
   - 1.1 Examples
 - 2\. Common Properties
+- 3\. Helpful resources
+  - 3.1 Converter
+  - 3.2 Tutorial
+
 
 ## 1. Introduction
 
@@ -100,3 +104,14 @@ Property | Type | Required? | Description | Example
 `"label"` | `string` | no | A short label that represents the item within the discovery aid. Often times this can be a "sheet number" for paper maps. | `"L-16"`
 `"title"` | `string` | no | A title for the given item. Usually longer than the `label`. Sometimes the label is included in this title. | `"Tōa yochizu -- 東亞輿地圖 -- L-16"`
 `"note"` | `string` | no | Additional information that should be presented to the user | `"This item is really interesting."`
+
+## 3. Helpful Resources
+
+### 3.1 Converter
+
+A [converter](https://openindexmaps.org/converter) is available for converting shapefile index maps to OpenIndexMaps GeoJSON.
+
+### 3.2 Tutorial
+
+A [Creating GeoJSON for OpenIndexMaps](https://kgjenkins.github.io/openindexmaps-workshop/) tutorial was created for a workshop at Geo4LibCamp 2020.  The tutorial works through several examples of using QGIS to create OpenIndexMaps GeoJSON files.
+


### PR DESCRIPTION
I've added a section 3, with links to:
- the shapefile-to-geojson converter page
- the OpenIndexMaps workshop tutorial from Geo4LibCamp

I only edited the index.md page, but am running into errors when trying to view as GitHub Pages in my fork of the repo:

> Your site is having problems building: Your SCSS file assets/main.scss has an error on line 5: File to import not found or unreadable: ../node_modules/bootstrap/scss/functions. Load paths: _sass /hoosegow/.bundle/ruby/2.5.0/gems/jekyll-theme-primer-0.5.4/_sass /hoosegow/.bundle/ruby/2.5.0/gems/jekyll-theme-primer-0.5.4/_sass. For more information, see https://help.github.com/en/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites#invalid-sass-or-scss.

But maybe I'm missing something from the way things are set up in the the original repo...